### PR TITLE
Remove Committee Tab Temporarily

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -4,8 +4,6 @@ links:
     collection: about-lkm
   - title: MEMBER BENEFITS
     url: /benefits
-  - title: THE COMMITTEE
-    collection: the-committee
   - title: GET IN TOUCH
     url: /contact-us/
   - title: BE A MEMBER


### PR DESCRIPTION
In fixing the alignment of the pages, committee tab to be removed from the page entirely first.